### PR TITLE
Refactor Logger import and update doPost test setup

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -1,9 +1,6 @@
 /** 
  * @see https://developers.google.com/apps-script/guides/triggers
  */
-
-const Logger = require("@ilanlal/gasmocks/src/base/classes/Logger");
-
 function onInstall(e) {
     onOpen(e);
 }

--- a/src/Code.test.js
+++ b/src/Code.test.js
@@ -54,6 +54,8 @@ describe('doPost', () => {
 
     // Error handling test
     it('should handle errors in doPost gracefully', () => {
+        PropertiesService.getDocumentProperties().setProperty(EnvironmentModel.InputMeta.BOT_API_TOKEN, dummyToken);
+
         const event = {
             postData: { contents: 'invalid json' }
         };


### PR DESCRIPTION
Remove an unused Logger import and ensure the doPost test sets the BOT_API_TOKEN for proper testing.